### PR TITLE
Add usage example to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Further reading:
 
 ## Quick start 
  
-### Node 
+### Node.js
  
 Create an empty directory and install the [runtime from npm](https://www.npmjs.com/package/kaitai-struct) by running: 
  
@@ -22,7 +22,7 @@ Create an empty directory and install the [runtime from npm](https://www.npmjs.c
 npm i kaitai-struct 
 ``` 
  
-Copy your compiled .ksy parser (eg. `Elf.js`) or download a [parser from the format gallery](http://formats.kaitai.io/) to the directory. 
+Copy your compiled .ksy parser (eg. `Elf.js`) or download a [parser from the format gallery](http://formats.kaitai.io/) (eg. [Elf.js](http://formats.kaitai.io/elf/javascript.html)) to this directory. 
  
 Create `index.js` with the following content: 
  

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Test the code by running `node index.js`.
 ## Licensing
 
 Copyright 2012-2016 Ilmari Heikkinen
-Copyright 2016-2017 Kaitai Project
+Copyright 2016-2018 Kaitai Project
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,32 @@ Further reading:
 * [About API implemented in this library](http://doc.kaitai.io/stream_api.html)
 * [JavaScript-specific notes](http://doc.kaitai.io/lang_javascript.html)
 
+## Quick start 
+ 
+### Node 
+ 
+Create an empty directory and install the [runtime from npm](https://www.npmjs.com/package/kaitai-struct) by running: 
+ 
+```bash
+npm i kaitai-struct 
+``` 
+ 
+Copy your compiled .ksy parser (eg. `Elf.js`) or download a [parser from the format gallery](http://formats.kaitai.io/) to the directory. 
+ 
+Create `index.js` with the following content: 
+ 
+```javascript 
+const fs = require("fs"); 
+const Elf = require("./Elf"); 
+const KaitaiStream = require('kaitai-struct/KaitaiStream'); 
+ 
+const fileContent = fs.readFileSync("/bin/ls"); 
+const parsedElf = new Elf(new KaitaiStream(fileContent)); 
+console.log(parsedElf); 
+``` 
+ 
+Test the code by running `node index.js`. 
+
 ## Licensing
 
 Copyright 2012-2016 Ilmari Heikkinen


### PR DESCRIPTION
I did not find any good copy-paste code how to use the library, and I think the code on the homepage is incorrect (in this code `var g = new Gif(someArrayBuffer);` the `Gif` constructor actually expects `KaitaiStream`, not `someArrayBuffer`), and this repo's README is what Google find first for searches like "Kaitai Javascript", so I thought it would be a good place to put this example.