### PR TITLE
Fix operator precedence error with signed integer reading.

### DIFF
--- a/KaitaiStream.js
+++ b/KaitaiStream.js
@@ -213,7 +213,7 @@ KaitaiStream.prototype.readS8be = function(e) {
   var v1 = this.readU4be();
   var v2 = this.readU4be();
 
-  if (v1 & 0x80000000 != 0) {
+  if ((v1 & 0x80000000) != 0) {
     // negative number
     return -(0x100000000 * (v1 ^ 0xffffffff) + (v2 ^ 0xffffffff)) - 1;
   } else {
@@ -256,7 +256,7 @@ KaitaiStream.prototype.readS8le = function(e) {
   var v1 = this.readU4le();
   var v2 = this.readU4le();
 
-  if (v2 & 0x80000000 != 0) {
+  if ((v2 & 0x80000000) != 0) {
     // negative number
     return -(0x100000000 * (v2 ^ 0xffffffff) + (v1 ^ 0xffffffff)) - 1;
   } else {


### PR DESCRIPTION
TypeScript caught that these branches were always false... because of operator precedence.

I have not checked to see if this fixes an actual bug or not. It may be worth adding a test case for this first, if it actually does.