### PR TITLE
Fix processZlib for Node versions below v5.10.0

### DIFF
--- a/KaitaiStream.js
+++ b/KaitaiStream.js
@@ -605,7 +605,7 @@ KaitaiStream.processZlib = function(buf) {
       KaitaiStream.zlib = require('zlib');
     // use node's zlib module API
     var r = KaitaiStream.zlib.inflateSync(
-      Buffer.from(buf.buffer, buf.byteOffset, buf.byteLength)
+      Buffer.from(buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength))
     );
     return r;
   } else {


### PR DESCRIPTION
- uses `Buffer.from(arrayBuffer)` added in v4.5.0
- uses `ArrayBuffer.slice` which is supported since [Chrome 17](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/slice#Browser_compatibility) from 2012

Ref #3 