### PR TITLE
Make compatible with ES5

### DIFF
--- a/KaitaiStream.js
+++ b/KaitaiStream.js
@@ -419,7 +419,7 @@ KaitaiStream.prototype.alignToByte = function() {
 KaitaiStream.prototype.readBitsIntBe = function(n) {
   // JS only supports bit operations on 32 bits
   if (n > 32) {
-    throw new Error(`readBitsIntBe: the maximum supported bit length is 32 (tried to read ${n} bits)`);
+    throw new Error("readBitsIntBe: the maximum supported bit length is 32 (tried to read " + n + " bits)");
   }
   var bitsNeeded = n - this.bitsLeft;
   if (bitsNeeded > 0) {
@@ -458,7 +458,7 @@ KaitaiStream.prototype.readBitsInt = KaitaiStream.prototype.readBitsIntBe;
 KaitaiStream.prototype.readBitsIntLe = function(n) {
   // JS only supports bit operations on 32 bits
   if (n > 32) {
-    throw new Error(`readBitsIntLe: the maximum supported bit length is 32 (tried to read ${n} bits)`);
+    throw new Error("readBitsIntLe: the maximum supported bit length is 32 (tried to read " + n + " bits)");
   }
   var bitsNeeded = n - this.bitsLeft;
   if (bitsNeeded > 0) {


### PR DESCRIPTION
template literal syntax is only available in ES6. By changing how the
error message is generated, KaitaiStream.js can run under ES5.