### PR TITLE
Migrate to TypeScript 6.0, set TypeScript target to ES6 (ES2015 / ECMAScript 2015)

### DIFF
--- a/KaitaiStream.ts
+++ b/KaitaiStream.ts
@@ -1040,8 +1040,6 @@ namespace KaitaiStream {
      */
     public constructor(bytesReq: number, bytesAvail: number) {
       super("requested " + bytesReq + " bytes, but only " + bytesAvail + " bytes available");
-      // Workaround https://www.typescriptlang.org/docs/handbook/2/classes.html#inheriting-built-in-types
-      Object.setPrototypeOf(this, KaitaiStream.EOFError.prototype);
       this.bytesReq = bytesReq;
       this.bytesAvail = bytesAvail;
     }
@@ -1061,8 +1059,6 @@ namespace KaitaiStream {
      */
     public constructor(expected: any, actual: any) {
       super("expected [" + expected + "], but got [" + actual + "]");
-      // Workaround https://www.typescriptlang.org/docs/handbook/2/classes.html#inheriting-built-in-types
-      Object.setPrototypeOf(this, KaitaiStream.UnexpectedDataError.prototype);
       this.expected = expected;
       this.actual = actual;
     }
@@ -1073,8 +1069,6 @@ namespace KaitaiStream {
 
     public constructor() {
       super();
-      // Workaround https://www.typescriptlang.org/docs/handbook/2/classes.html#inheriting-built-in-types
-      Object.setPrototypeOf(this, KaitaiStream.UndecidedEndiannessError.prototype);
     }
   };
 
@@ -1089,8 +1083,6 @@ namespace KaitaiStream {
      */
     public constructor(expected: any, actual: any) {
       super("not equal, expected [" + expected + "], but got [" + actual + "]");
-      // Workaround https://www.typescriptlang.org/docs/handbook/2/classes.html#inheriting-built-in-types
-      Object.setPrototypeOf(this, KaitaiStream.ValidationNotEqualError.prototype);
       this.expected = expected;
       this.actual = actual;
     }
@@ -1107,8 +1099,6 @@ namespace KaitaiStream {
      */
     public constructor(min: any, actual: any) {
       super("not in range, min [" + min + "], but got [" + actual + "]");
-      // Workaround https://www.typescriptlang.org/docs/handbook/2/classes.html#inheriting-built-in-types
-      Object.setPrototypeOf(this, KaitaiStream.ValidationLessThanError.prototype);
       this.min = min;
       this.actual = actual;
     }
@@ -1125,8 +1115,6 @@ namespace KaitaiStream {
      */
     public constructor(max: any, actual: any) {
       super("not in range, max [" + max + "], but got [" + actual + "]");
-      // Workaround https://www.typescriptlang.org/docs/handbook/2/classes.html#inheriting-built-in-types
-      Object.setPrototypeOf(this, KaitaiStream.ValidationGreaterThanError.prototype);
       this.max = max;
       this.actual = actual;
     }
@@ -1141,8 +1129,6 @@ namespace KaitaiStream {
      */
     public constructor(actual: any) {
       super("not any of the list, got [" + actual + "]");
-      // Workaround https://www.typescriptlang.org/docs/handbook/2/classes.html#inheriting-built-in-types
-      Object.setPrototypeOf(this, KaitaiStream.ValidationNotAnyOfError.prototype);
       this.actual = actual;
     }
   };
@@ -1156,8 +1142,6 @@ namespace KaitaiStream {
      */
     public constructor(actual: any) {
       super("not in the enum, got [" + actual + "]");
-      // Workaround https://www.typescriptlang.org/docs/handbook/2/classes.html#inheriting-built-in-types
-      Object.setPrototypeOf(this, KaitaiStream.ValidationNotInEnumError.prototype);
       this.actual = actual;
     }
   };
@@ -1171,8 +1155,6 @@ namespace KaitaiStream {
      */
     public constructor(actual: any) {
       super("not matching the expression, got [" + actual + "]");
-      // Workaround https://www.typescriptlang.org/docs/handbook/2/classes.html#inheriting-built-in-types
-      Object.setPrototypeOf(this, KaitaiStream.ValidationExprError.prototype);
       this.actual = actual;
     }
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@types/node": "^24.12.0",
         "rollup": "^4.59.0",
         "tslib": "^2.8.1",
-        "typescript": "^5.9.3"
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@rollup/plugin-typescript": {
@@ -601,9 +601,9 @@
       "license": "0BSD"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "@types/node": "^24.12.0",
     "rollup": "^4.59.0",
     "tslib": "^2.8.1",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,9 +26,9 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "es2015",                                  /* Specify what module code is generated. */
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    "module": "preserve",                                /* Specify what module code is generated. */
+    "rootDir": "./",                                     /* Specify the root folder within your source files. */
+    "moduleResolution": "bundler",                       /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es5",                                     /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es6",                                     /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "libReplacement": true,                           /* Enable lib replacement. */
@@ -33,7 +33,7 @@
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    "types": ["node"],                                   /* Specify type package names to be included without being referenced in a source file. */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
     // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */


### PR DESCRIPTION
Related issue: https://github.com/kaitai-io/kaitai_struct/issues/539

See also https://github.com/kaitai-io/kaitai_struct/issues/542#issuecomment-4208127329

---

The ECMAScript 5 (ES5) target was deprecated in TypeScript 6.0, see https://www.typescriptlang.org/docs/handbook/release-notes/typescript-6-0.html#deprecated-target-es5. ES6 (ES2015) is now the TypeScript's lowest target.

ES6 is widely supported across JavaScript engines, see https://compat-table.github.io/compat-table/es6/. As can be seen from this table and also from https://zoo.js.org/, there are several non-mainstream JS engines that don't support ES6 classes (which is the main feature we need), namely:

* Rhino 1.9.0 - see https://github.com/mozilla/rhino/issues/835 and https://github.com/ivankra/javascript-zoo-data/blob/8d76f329c686f006081842b5c5091880e49efd03/compat-table/rhino.json#L400
* (Hermes 0.12.0) - see https://github.com/facebook/hermes/issues/685; Hermes 0.13.0 likely already supports them, Hermes V1 (the default `static_h` branch of the https://github.com/facebook/hermes repo; see https://zoo.js.org/#hermes-v1) definitely does, see https://github.com/ivankra/javascript-zoo-data/blob/8d76f329c686f006081842b5c5091880e49efd03/compat-table/hermes_full.json#L381-L404
* Nashorn 15.7 (labeled "JJS 1.8" at https://compat-table.github.io/compat-table/es6/) - see https://github.com/ivankra/javascript-zoo-data/blob/8d76f329c686f006081842b5c5091880e49efd03/compat-table/nashorn.json#L401 and https://bugs.openjdk.org/browse/JDK-8066046
* Duktape 2.7 - apparently abandoned, see https://github.com/svaarala/duktape (last release in February 2022 and no commits since January 2024)

I believe it makes sense to leave these rather outdated JavaScript runtimes behind and no longer support them out of the box in future versions of Kaitai Struct. If any of our users use one of the runtimes listed above or another ES5-only runtime, they can continue using existing versions of Kaitai Struct, or use [Babel](https://babeljs.io/) to transpile ES6 code to ES5.